### PR TITLE
Add Deepwiki reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ pip install -r requirements.txt
 pytest
 ```
 
+## Additional Documentation
+
+For a deeper look at the project, refer to the [ExactTranscriber Deepwiki page](https://deepwiki.com/cyanxxy/ExactTranscriber).
+


### PR DESCRIPTION
## Summary
- document a link to in-depth project info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jinja2')*